### PR TITLE
refactor: move hooks to `dev.slne.surf.lobby.hook` package and enable…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     compileOnly("dev.slne.surf.parkour:surf-parkour-api:1.21.11-3.1.2-SNAPSHOT")
     compileOnly("dev.slne.surf.trophy:surf-trophy-api:1.21.11-1.0.0-SNAPSHOT")
     compileOnly("dev.slne.surf.profile:surf-profile-api:1.21.11-1.0.0-SNAPSHOT")
+    compileOnly("dev.slne.surf.settings:surf-settings-api:1.21.11-2.0.0-SNAPSHOT")
 }
 
 version = findProperty("version") as String
@@ -38,5 +39,6 @@ surfPaperPluginApi {
         registerSoft("Nexo")
         registerSoft("surf-trophy-paper")
         registerSoft("surf-profile-paper")
+        registerSoft("surf-settings-paper")
     }
 }

--- a/src/main/kotlin/dev/slne/surf/lobby/PaperMain.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/PaperMain.kt
@@ -5,11 +5,11 @@ import dev.slne.surf.lobby.command.lobbyCommand
 import dev.slne.surf.lobby.command.spawnCommand
 import dev.slne.surf.lobby.config.LobbyConfigHolder
 import dev.slne.surf.lobby.event.eventServerBridge
-import dev.slne.surf.lobby.hologram.SurfHologramHook
+import dev.slne.surf.lobby.hook.hologram.SurfHologramHook
+import dev.slne.surf.lobby.hook.nexo.NexoHook
+import dev.slne.surf.lobby.hook.npc.SurfNpcHook
 import dev.slne.surf.lobby.listener.*
 import dev.slne.surf.lobby.manager.PushbackManager
-import dev.slne.surf.lobby.nexo.NexoHook
-import dev.slne.surf.lobby.npc.SurfNpcHook
 import dev.slne.surf.redis.RedisApi
 import dev.slne.surf.surfapi.bukkit.api.event.register
 import org.bukkit.Bukkit

--- a/src/main/kotlin/dev/slne/surf/lobby/command/LobbyCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/command/LobbyCommand.kt
@@ -3,8 +3,8 @@ package dev.slne.surf.lobby.command
 import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.commandTree
 import dev.jorel.commandapi.kotlindsl.literalArgument
+import dev.slne.surf.lobby.hook.npc.SurfNpcHook
 import dev.slne.surf.lobby.lobbyConfigHolder
-import dev.slne.surf.lobby.npc.SurfNpcHook
 import dev.slne.surf.lobby.surfNpcHook
 import dev.slne.surf.lobby.utils.PermissionRegistry
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/hologram/SurfHologramHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/hologram/SurfHologramHook.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.hologram
+package dev.slne.surf.lobby.hook.hologram
 
 import dev.slne.surf.hologram.api.hologram.Hologram
 

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/nexo/NexoHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/nexo/NexoHook.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.nexo
+package dev.slne.surf.lobby.hook.nexo
 
 import com.nexomc.nexo.api.NexoItems
 import org.bukkit.inventory.ItemType

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/npc/SurfNpcHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/npc/SurfNpcHook.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.npc
+package dev.slne.surf.lobby.hook.npc
 
 import dev.slne.surf.event.base.api.common.state.EventServerState
 import dev.slne.surf.lobby.event.eventServerBridge

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/npc/SurfNpcSkins.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/npc/SurfNpcSkins.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.npc
+package dev.slne.surf.lobby.hook.npc
 
 import dev.slne.surf.npc.api.surfNpcApi
 

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/parkour/ParkourHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/parkour/ParkourHook.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.parkour
+package dev.slne.surf.lobby.hook.parkour
 
 import dev.slne.surf.parkour.api.surfParkourApi
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/profile/ProfileHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/profile/ProfileHook.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.profile
+package dev.slne.surf.lobby.hook.profile
 
 import dev.slne.surf.profile.api.surfProfileApi
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/settings/SettingsHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/settings/SettingsHook.kt
@@ -1,0 +1,18 @@
+package dev.slne.surf.lobby.hook.settings
+
+import dev.slne.surf.settings.api.surfSettingsApi
+import org.bukkit.Bukkit
+import java.util.*
+
+object SettingsHook {
+    fun isEnabled() = Bukkit.getPluginManager().isPluginEnabled("surf-settings-paper")
+
+    fun hasScrollSoundsEnabled(playerUuid: UUID): Boolean {
+        return if (isEnabled()) {
+            surfSettingsApi.getPlayerSetting(playerUuid, "lobby_scroll_sound")?.getBoolean()
+                ?: false
+        } else {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/trophy/TrophyHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/trophy/TrophyHook.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.lobby.trophy
+package dev.slne.surf.lobby.hook.trophy
 
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.trophy.api.surfTrophyApi

--- a/src/main/kotlin/dev/slne/surf/lobby/inventory/item/impl/parkour/ParkourItem.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/inventory/item/impl/parkour/ParkourItem.kt
@@ -1,8 +1,8 @@
 package dev.slne.surf.lobby.inventory.item.impl.parkour
 
 import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.lobby.hook.parkour.ParkourHook
 import dev.slne.surf.lobby.inventory.item.InventoryItem
-import dev.slne.surf.lobby.parkour.ParkourHook
 import dev.slne.surf.lobby.plugin
 import dev.slne.surf.surfapi.bukkit.api.builder.buildLore
 import dev.slne.surf.surfapi.bukkit.api.builder.displayName

--- a/src/main/kotlin/dev/slne/surf/lobby/inventory/item/impl/profile/ProfileItem.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/inventory/item/impl/profile/ProfileItem.kt
@@ -1,7 +1,7 @@
 package dev.slne.surf.lobby.inventory.item.impl.profile
 
+import dev.slne.surf.lobby.hook.profile.ProfileHook
 import dev.slne.surf.lobby.inventory.item.InventoryItem
-import dev.slne.surf.lobby.profile.ProfileHook
 import dev.slne.surf.surfapi.bukkit.api.builder.buildLore
 import dev.slne.surf.surfapi.bukkit.api.builder.displayName
 import dev.slne.surf.surfapi.core.api.font.toSmallCaps

--- a/src/main/kotlin/dev/slne/surf/lobby/inventory/item/impl/rewards/TrophiesItem.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/inventory/item/impl/rewards/TrophiesItem.kt
@@ -1,7 +1,7 @@
 package dev.slne.surf.lobby.inventory.item.impl.rewards
 
+import dev.slne.surf.lobby.hook.trophy.TrophyHook
 import dev.slne.surf.lobby.inventory.item.InventoryItem
-import dev.slne.surf.lobby.trophy.TrophyHook
 import dev.slne.surf.surfapi.bukkit.api.builder.buildLore
 import dev.slne.surf.surfapi.bukkit.api.builder.displayName
 import dev.slne.surf.surfapi.core.api.font.toSmallCaps

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
@@ -1,6 +1,6 @@
 package dev.slne.surf.lobby.listener
 
-import dev.slne.surf.lobby.parkour.ParkourHook
+import dev.slne.surf.lobby.hook.parkour.ParkourHook
 import dev.slne.surf.surfapi.bukkit.api.event.cancel
 import org.bukkit.GameMode
 import org.bukkit.Particle

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/InventoryInteractListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/InventoryInteractListener.kt
@@ -1,11 +1,16 @@
 package dev.slne.surf.lobby.listener
 
+import dev.slne.surf.lobby.hook.settings.SettingsHook
+import dev.slne.surf.lobby.inventory.item.InventoryItem
 import dev.slne.surf.surfapi.bukkit.api.event.cancel
+import dev.slne.surf.surfapi.core.api.messages.adventure.playSound
 import org.bukkit.GameMode
+import org.bukkit.Sound
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.player.PlayerDropItemEvent
+import org.bukkit.event.player.PlayerItemHeldEvent
 import org.bukkit.event.player.PlayerSwapHandItemsEvent
 
 object InventoryInteractListener : Listener {
@@ -53,14 +58,18 @@ object InventoryInteractListener : Listener {
         event.cancel()
     }
 
-//    @EventHandler
-//    fun onHoldItem(event: PlayerItemHeldEvent) {
-//        if (InventoryItem.items.filter { item ->
-//                item.permission?.let { event.player.hasPermission(it) } ?: true
-//            }.any { it.slot == event.newSlot }) {
-//            event.player.playSound(true) {
-//                type(Sound.UI_BUTTON_CLICK)
-//            }
-//        }
-//    }
+    @EventHandler
+    fun onHoldItem(event: PlayerItemHeldEvent) {
+        if (!SettingsHook.hasScrollSoundsEnabled(event.player.uniqueId)) {
+            return
+        }
+
+        if (InventoryItem.items.filter { item ->
+                item.permission?.let { event.player.hasPermission(it) } ?: true
+            }.any { it.slot == event.newSlot }) {
+            event.player.playSound(true) {
+                type(Sound.UI_BUTTON_CLICK)
+            }
+        }
+    }
 }


### PR DESCRIPTION
… settings integration

- Relocated various hook classes (e.g., `ParkourHook`, `TrophyHook`) to `dev.slne.surf.lobby.hook` for improved structure.
- Added `SettingsHook` to integrate with `surf-settings` API.
- Updated `InventoryInteractListener` to utilize scroll sound settings.