### PR TITLE
Fix/fix trophy api +  input packets double jump

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("dev.slne.surf.event:surf-event-base-api-common:1.21.11-1.0.0-SNAPSHOT")
     implementation("dev.slne.surf.tab:surf-tab-api:1.21.11-1.0.2-SNAPSHOT")
     compileOnly("dev.slne.surf.parkour:surf-parkour-api:1.21.11-3.4.0-SNAPSHOT")
-    compileOnly("dev.slne.surf.trophy:surf-trophy-api:1.21.11-1.0.0-SNAPSHOT")
+    compileOnly("dev.slne.surf.trophy:surf-trophy-api:1.21.11-1.1.0-SNAPSHOT")
     compileOnly("dev.slne.surf.profile:surf-profile-api:1.21.11-1.0.0-SNAPSHOT")
     compileOnly("dev.slne.surf.settings:surf-settings-api:1.21.11-2.0.0-SNAPSHOT")
     compileOnly("dev.slne.surf:surf-queue-api:1.0.0-SNAPSHOT")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.11-3.0.12-SNAPSHOT
+version=1.21.11-3.0.13-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.11-3.0.11-SNAPSHOT
+version=1.21.11-3.0.12-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/lobby/PaperMain.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/PaperMain.kt
@@ -68,3 +68,4 @@ val lobbyConfig get() = lobbyConfigHolder.lobbyConfig
 val surfNpcHook get() = Bukkit.getPluginManager().isPluginEnabled("surf-npc-paper")
 val surfHologramHook get() = Bukkit.getPluginManager().isPluginEnabled("surf-hologram-paper")
 val nexoHook get() = Bukkit.getPluginManager().isPluginEnabled("Nexo")
+val parkourHook get() = Bukkit.getPluginManager().isPluginEnabled("surf-parkour-paper")

--- a/src/main/kotlin/dev/slne/surf/lobby/hook/trophy/TrophyHook.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/hook/trophy/TrophyHook.kt
@@ -10,7 +10,7 @@ object TrophyHook {
 
     fun openMenu(player: Player) {
         if (isEnabled()) {
-            surfTrophyApi.showTrophyMenu(player, player)
+            surfTrophyApi.showTrophyMenu(player.uniqueId, player.uniqueId)
         } else {
             player.sendText {
                 appendErrorPrefix()

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
@@ -1,66 +1,49 @@
 package dev.slne.surf.lobby.listener
 
 import dev.slne.surf.lobby.hook.parkour.ParkourHook
-import dev.slne.surf.surfapi.bukkit.api.event.cancel
+import dev.slne.surf.lobby.parkourHook
+import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import org.bukkit.GameMode
 import org.bukkit.Particle
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import org.bukkit.event.player.PlayerMoveEvent
-import org.bukkit.event.player.PlayerToggleFlightEvent
+import org.bukkit.event.player.PlayerInputEvent
+import java.util.*
 
 object DoubleJumpListener : Listener {
-    @EventHandler
-    fun onPlayerMove(event: PlayerMoveEvent) {
-        if (!event.hasExplicitlyChangedBlock()) {
-            return
-        }
-
-        val player = event.getPlayer()
-
-        if (ParkourHook.isInParkour(player)) {
-            if (player.gameMode == GameMode.CREATIVE) {
-                return
-            }
-
-            player.allowFlight = false
-            return
-        }
-
-
-        if (player.gameMode != GameMode.CREATIVE &&
-            player.isOnGround &&
-            !player.isFlying
-        ) {
-            player.allowFlight = true
-        }
-    }
+    private val lastJump = mutableObject2ObjectMapOf<UUID, Long>()
+    private const val DOUBLE_JUMP_WINDOW = 400L
 
     @EventHandler
-    fun onPlayerToggleFlight(event: PlayerToggleFlightEvent) {
-        val player = event.getPlayer()
+    fun onInput(event: PlayerInputEvent) {
+        val player = event.player
 
-        if (player.gameMode == GameMode.CREATIVE) {
+        if (!event.input.isJump) {
             return
         }
 
-        if (ParkourHook.isInParkour(player)) {
+        if (player.gameMode == GameMode.CREATIVE || player.gameMode == GameMode.SPECTATOR) {
             return
         }
 
-        if (!player.allowFlight) {
+        if (parkourHook && ParkourHook.isInParkour(player)) 7
+
+        val now = System.currentTimeMillis()
+        val last = lastJump[player.uniqueId]
+
+        if (player.isOnGround) {
+            lastJump[player.uniqueId] = now
             return
         }
 
-        val direction = player.eyeLocation.direction
-        val loc = player.location
+        if (last != null && now - last <= DOUBLE_JUMP_WINDOW) {
+            val direction = player.eyeLocation.direction
+            val loc = player.location
 
-        player.velocity = direction.multiply(2).setY(1)
-        loc.getWorld().spawnParticle(Particle.EXPLOSION, loc, 10)
+            player.velocity = direction.multiply(2).setY(1)
+            loc.world.spawnParticle(Particle.EXPLOSION, loc, 10)
 
-        player.allowFlight = false
-        player.isFlying = false
-
-        event.cancel()
+            lastJump.remove(player.uniqueId)
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the lobby system, focusing mainly on the double jump mechanic and plugin integration. The most notable changes include a complete refactor of the double jump logic to use `PlayerInputEvent`, improved parkour plugin detection, and a version bump.

**Double Jump Refactor:**

* [`DoubleJumpListener.kt`](diffhunk://#diff-90d2e5a3debba52549c6629fa5dbc567c82150376ac0b44b926f09cf37645cb4L4-R47): Refactored double jump logic to use `PlayerInputEvent` instead of movement and flight events, added a cooldown window for double jumps, and improved compatibility with parkour and creative/spectator modes.

**Plugin Integration:**

* [`PaperMain.kt`](diffhunk://#diff-ab34b22b3b1edaef5e86ea3b6ad58c5cb12ab8a44d9860caa1780fc4ca8841e6R71): Added detection for the `surf-parkour-paper` plugin with the new `parkourHook` property.

**API Usage Improvement:**

* [`TrophyHook.kt`](diffhunk://#diff-be7b54dbe6302b0f878ad4c888a676517883f31caaffc8831b9f2aeb10bd9ddfL13-R13): Updated `openMenu` to use player UUIDs instead of player objects when calling the trophy API.

**Versioning:**

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L4-R4): Bumped the project version from `1.21.11-3.0.11-SNAPSHOT` to `1.21.11-3.0.13-SNAPSHOT`.