### PR TITLE
🐛 fix(double-jump): improve double jump mechanics and ground detection logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=3.1.3
+version=3.1.4

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
@@ -47,6 +47,8 @@ object DoubleJumpListener : Listener {
      */
     private val needsGroundReset = ConcurrentHashMap.newKeySet<UUID>()
 
+    private val holdingJump = ConcurrentHashMap.newKeySet<UUID>()
+
     /**
      * Handles jump input and triggers the double jump when the player presses
      * jump twice within the configured time window.
@@ -61,7 +63,14 @@ object DoubleJumpListener : Listener {
         val player = event.player
         val uuid = player.uniqueId
 
-        if (!event.input.isJump) return
+        val isJumping = event.input.isJump
+        if (isJumping) {
+            if (!holdingJump.add(uuid)) return
+        } else {
+            holdingJump.remove(uuid)
+            return
+        }
+
         if (player.gameMode == GameMode.CREATIVE || player.gameMode == GameMode.SPECTATOR) return
         if (needsGroundReset.contains(uuid)) return
         if (plugin.checkParkourHook() && ParkourHook.isInParkour(player)) return
@@ -123,6 +132,6 @@ object DoubleJumpListener : Listener {
     private fun Player.isTouchingGround(): Boolean {
         val blockLocation = location.toBlockLocation()
         blockLocation.y -= 1
-        return !blockLocation.block.isEmpty
+        return blockLocation.block.isSolid
     }
 }

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
@@ -1,69 +1,126 @@
 package dev.slne.surf.lobby.listener
 
-import dev.slne.surf.api.core.util.mutableObject2ObjectMapOf
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.sksamuel.aedile.core.expireAfterWrite
 import dev.slne.surf.lobby.hook.parkour.ParkourHook
+import dev.slne.surf.lobby.listener.DoubleJumpListener.doubleJumpWindow
 import dev.slne.surf.lobby.plugin
-import org.bukkit.GameMode
 import org.bukkit.Particle
+import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerInputEvent
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerQuitEvent
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.milliseconds
 
+/**
+ * Handles the lobby double-jump mechanic.
+ *
+ * The first jump starts a short time window in which a second jump input
+ * triggers a boosted jump. After a successful double jump, the player must
+ * touch the ground again before another double jump can be performed.
+ */
 object DoubleJumpListener : Listener {
-    private val lastJump = mutableObject2ObjectMapOf<UUID, Long>()
-    private val lastGround = mutableObject2ObjectMapOf<UUID, Long>()
-    private val lastJumpState = mutableObject2ObjectMapOf<UUID, Boolean>()
 
-    private const val DOUBLE_JUMP_WINDOW = 350L
-    private const val GROUND_GRACE = 150L
+    /**
+     * The maximum time between the first and second jump input.
+     */
+    private val doubleJumpWindow = 350.milliseconds
 
-    @EventHandler
+    /**
+     * Stores players that recently pressed jump once.
+     *
+     * Entries expire automatically after [doubleJumpWindow], so a second jump
+     * only counts if it happens shortly after the first one.
+     */
+    private val lastJump = Caffeine.newBuilder()
+        .expireAfterWrite(doubleJumpWindow)
+        .build<UUID, Boolean>()
+
+    /**
+     * Stores players that have already used their double jump and must touch
+     * the ground before they can double jump again.
+     */
+    private val needsGroundReset = ConcurrentHashMap.newKeySet<UUID>()
+
+    /**
+     * Handles jump input and triggers the double jump when the player presses
+     * jump twice within the configured time window.
+     *
+     * Players that are currently inside a parkour session or still need to
+     * touch the ground again are ignored.
+     *
+     * @param event the player input event
+     */
+    @EventHandler(ignoreCancelled = true)
     fun onInput(event: PlayerInputEvent) {
         val player = event.player
         val uuid = player.uniqueId
 
-        val isJumping = event.input.isJump
-        val wasJumping = lastJumpState[uuid] ?: false
-        lastJumpState[uuid] = isJumping
+        if (!event.input.isJump) return
+        if (needsGroundReset.contains(uuid)) return
+        if (plugin.checkParkourHook() && ParkourHook.isInParkour(player)) return
 
-        if (!isJumping || wasJumping) {
-            return
+        var doDoubleJump = false
+        lastJump.asMap().compute(uuid) { _, previous ->
+            if (previous == null) {
+                true // first jump — mark jump window
+            } else {
+                doDoubleJump = true
+                null // second jump — consume jump window
+            }
         }
 
-        if (player.gameMode == GameMode.CREATIVE || player.gameMode == GameMode.SPECTATOR) {
-            return
-        }
+        if (!doDoubleJump) return
 
-        if (plugin.checkParkourHook() && ParkourHook.isInParkour(player)) {
-            return
-        }
+        needsGroundReset.add(uuid)
 
-        val now = System.currentTimeMillis()
+        player.velocity = player.eyeLocation.direction.multiply(2).setY(1.0)
+        player.world.spawnParticle(Particle.EXPLOSION, player.location, 10)
+    }
 
-        if (player.isOnGround) {
-            lastGround[uuid] = now
-        }
+    /**
+     * Clears the double-jump reset state once a player touches the ground again.
+     *
+     * This allows the player to perform another double jump after landing.
+     *
+     * @param event the player movement event
+     */
+    @EventHandler(ignoreCancelled = true)
+    fun onPlayerMove(event: PlayerMoveEvent) {
+        if (!event.hasExplicitlyChangedBlock()) return
 
-        val lastGroundTime = lastGround[uuid] ?: 0L
-        val lastJumpTime = lastJump[uuid]
+        val player = event.player
+        val uuid = player.uniqueId
 
-        val recentlyOnGround = now - lastGroundTime <= GROUND_GRACE
+        if (!needsGroundReset.contains(uuid)) return
+        if (!player.isTouchingGround()) return
 
-        if (lastJumpTime != null &&
-            now - lastJumpTime <= DOUBLE_JUMP_WINDOW &&
-            recentlyOnGround
-        ) {
-            player.velocity = player.eyeLocation.direction.multiply(2).setY(1.0)
-            player.world.spawnParticle(Particle.EXPLOSION, player.location, 10)
+        needsGroundReset.remove(uuid)
+        lastJump.invalidate(uuid)
+    }
 
-            lastJump.remove(uuid)
-            lastJumpState[uuid] = false
-            return
-        }
+    /**
+     * Cleans up the double-jump state when a player leaves the server.
+     *
+     * @param event the player quit event
+     */
+    @EventHandler
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        needsGroundReset.remove(event.player.uniqueId)
+    }
 
-        if (recentlyOnGround) {
-            lastJump[uuid] = now
-        }
+    /**
+     * Checks whether the player is standing on a non-empty block.
+     *
+     * @return `true` if there is a non-empty block below the player
+     */
+    private fun Player.isTouchingGround(): Boolean {
+        val blockLocation = location.toBlockLocation()
+        blockLocation.y -= 1
+        return !blockLocation.block.isEmpty
     }
 }

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
@@ -3,7 +3,6 @@ package dev.slne.surf.lobby.listener
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.sksamuel.aedile.core.expireAfterWrite
 import dev.slne.surf.lobby.hook.parkour.ParkourHook
-import dev.slne.surf.lobby.listener.DoubleJumpListener.doubleJumpWindow
 import dev.slne.surf.lobby.plugin
 import org.bukkit.GameMode
 import org.bukkit.Particle
@@ -17,121 +16,82 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.milliseconds
 
-/**
- * Handles the lobby double-jump mechanic.
- *
- * The first jump starts a short time window in which a second jump input
- * triggers a boosted jump. After a successful double jump, the player must
- * touch the ground again before another double jump can be performed.
- */
+
 object DoubleJumpListener : Listener {
 
-    /**
-     * The maximum time between the first and second jump input.
-     */
-    private val doubleJumpWindow = 350.milliseconds
+    private val DOUBLE_JUMP_WINDOW = 350.milliseconds
 
-    /**
-     * Stores players that recently pressed jump once.
-     *
-     * Entries expire automatically after [doubleJumpWindow], so a second jump
-     * only counts if it happens shortly after the first one.
-     */
-    private val lastJump = Caffeine.newBuilder()
-        .expireAfterWrite(doubleJumpWindow)
-        .build<UUID, Boolean>()
+    private val firstJumpWindow = Caffeine.newBuilder()
+        .expireAfterWrite(DOUBLE_JUMP_WINDOW)
+        .maximumSize(10_000)
+        .build<UUID, Unit>()
 
-    /**
-     * Stores players that have already used their double jump and must touch
-     * the ground before they can double jump again.
-     */
-    private val needsGroundReset = ConcurrentHashMap.newKeySet<UUID>()
+    private val usedDoubleJump = ConcurrentHashMap.newKeySet<UUID>()
+    private val jumpPressed = ConcurrentHashMap.newKeySet<UUID>()
 
-    private val holdingJump = ConcurrentHashMap.newKeySet<UUID>()
-
-    /**
-     * Handles jump input and triggers the double jump when the player presses
-     * jump twice within the configured time window.
-     *
-     * Players that are currently inside a parkour session or still need to
-     * touch the ground again are ignored.
-     *
-     * @param event the player input event
-     */
     @EventHandler(ignoreCancelled = true)
-    fun onInput(event: PlayerInputEvent) {
+    fun onPlayerInput(event: PlayerInputEvent) {
         val player = event.player
         val uuid = player.uniqueId
-
         val isJumping = event.input.isJump
-        if (isJumping) {
-            if (!holdingJump.add(uuid)) return
-        } else {
-            holdingJump.remove(uuid)
+
+        if (!canUseDoubleJump(player)) {
+            clearPlayer(uuid)
             return
         }
 
-        if (player.gameMode == GameMode.CREATIVE || player.gameMode == GameMode.SPECTATOR) return
-        if (needsGroundReset.contains(uuid)) return
-        if (plugin.checkParkourHook() && ParkourHook.isInParkour(player)) return
-
-        var doDoubleJump = false
-        lastJump.asMap().compute(uuid) { _, previous ->
-            if (previous == null) {
-                true // first jump — mark jump window
-            } else {
-                doDoubleJump = true
-                null // second jump — consume jump window
-            }
+        if (!isJumping) {
+            jumpPressed.remove(uuid)
+            return
         }
 
-        if (!doDoubleJump) return
+        val newJumpPress = jumpPressed.add(uuid)
+        if (!newJumpPress) return
 
-        needsGroundReset.add(uuid)
+        @Suppress("DEPRECATION")
+        if (player.isOnGround) {
+            usedDoubleJump.remove(uuid)
+            firstJumpWindow.put(uuid, Unit)
+            return
+        }
+
+        val hasValidFirstJump = firstJumpWindow.getIfPresent(uuid) != null
+        if (!hasValidFirstJump) return
+
+        val canDoubleJumpNow = usedDoubleJump.add(uuid)
+        if (!canDoubleJumpNow) return
+
+        firstJumpWindow.invalidate(uuid)
 
         player.velocity = player.eyeLocation.direction.multiply(2).setY(1.0)
         player.world.spawnParticle(Particle.EXPLOSION, player.location, 10)
     }
 
-    /**
-     * Clears the double-jump reset state once a player touches the ground again.
-     *
-     * This allows the player to perform another double jump after landing.
-     *
-     * @param event the player movement event
-     */
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
-        if (!event.hasExplicitlyChangedBlock()) return
-
+        if (!event.hasExplicitlyChangedPosition()) return
         val player = event.player
-        val uuid = player.uniqueId
 
-        if (!needsGroundReset.contains(uuid)) return
-        if (!player.isTouchingGround()) return
-
-        needsGroundReset.remove(uuid)
-        lastJump.invalidate(uuid)
+        @Suppress("DEPRECATION")
+        if (player.isOnGround) {
+            usedDoubleJump.remove(player.uniqueId)
+        }
     }
 
-    /**
-     * Cleans up the double-jump state when a player leaves the server.
-     *
-     * @param event the player quit event
-     */
     @EventHandler
     fun onPlayerQuit(event: PlayerQuitEvent) {
-        needsGroundReset.remove(event.player.uniqueId)
+        clearPlayer(event.player.uniqueId)
     }
 
-    /**
-     * Checks whether the player is standing on a non-empty block.
-     *
-     * @return `true` if there is a non-empty block below the player
-     */
-    private fun Player.isTouchingGround(): Boolean {
-        val blockLocation = location.toBlockLocation()
-        blockLocation.y -= 1
-        return blockLocation.block.isSolid
+    private fun clearPlayer(uuid: UUID) {
+        firstJumpWindow.invalidate(uuid)
+        usedDoubleJump.remove(uuid)
+        jumpPressed.remove(uuid)
+    }
+
+    private fun canUseDoubleJump(player: Player): Boolean {
+        if (player.gameMode == GameMode.CREATIVE || player.gameMode == GameMode.SPECTATOR) return false
+        if (plugin.checkParkourHook() && ParkourHook.isInParkour(player)) return false
+        return true
     }
 }

--- a/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
+++ b/src/main/kotlin/dev/slne/surf/lobby/listener/DoubleJumpListener.kt
@@ -5,6 +5,7 @@ import com.sksamuel.aedile.core.expireAfterWrite
 import dev.slne.surf.lobby.hook.parkour.ParkourHook
 import dev.slne.surf.lobby.listener.DoubleJumpListener.doubleJumpWindow
 import dev.slne.surf.lobby.plugin
+import org.bukkit.GameMode
 import org.bukkit.Particle
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -61,6 +62,7 @@ object DoubleJumpListener : Listener {
         val uuid = player.uniqueId
 
         if (!event.input.isJump) return
+        if (player.gameMode == GameMode.CREATIVE || player.gameMode == GameMode.SPECTATOR) return
         if (needsGroundReset.contains(uuid)) return
         if (plugin.checkParkourHook() && ParkourHook.isInParkour(player)) return
 


### PR DESCRIPTION
- adjust double jump logic to ensure players can only double jump after touching the ground
- implement a time window for jump inputs using Caffeine cache for better performance
- add event handlers for player movement and quitting to manage double jump state